### PR TITLE
Replace array constructor with loop to adopt OpenACC

### DIFF
--- a/SRC/subroutines/mkjp.f90
+++ b/SRC/subroutines/mkjp.f90
@@ -282,8 +282,12 @@ contains
                 ajr_tmp(1:nr(ibas),ig) = phi_rg(1:nr(ibas),ig,l)*rofi_tmp(1:nr(ibas))
                 call intn_smpxxx( rkpr(1,l,ibas), ajr_tmp(1,ig),int1x,aa(ibas),bb(ibas),rofi(1,ibas),nr(ibas))
                 call intn_smpxxx( rkmr(1,l,ibas), ajr_tmp(1,ig),int2x,aa(ibas),bb(ibas),rofi(1,ibas),nr(ibas))
-                a1g(1:nr(ibas),ig) = [0d0,(rkmr(2:nr(ibas),l,ibas) *( int1x(1)-int1x(2:nr(ibas)) ) &
-                                         + rkpr(2:nr(ibas),l,ibas) *  int2x(2:nr(ibas)))* fac_integral(2:nr(ibas))]
+                ! a1g(1:nr(ibas),ig) = [0d0,(rkmr(2:nr(ibas),l,ibas) *( int1x(1)-int1x(2:nr(ibas)) ) &
+                !                          + rkpr(2:nr(ibas),l,ibas) *  int2x(2:nr(ibas)))* fac_integral(2:nr(ibas))]  ! error in GPU version 08/18/2025
+                a1g(1,ig) = 0d0
+                do ir = 2, nr(ibas)
+                  a1g(ir,ig) = (rkmr(ir,l,ibas) * (int1x(1) - int1x(ir)) + rkpr(ir,l,ibas) * int2x(ir)) * fac_integral(ir)
+                enddo
               enddo
               !$acc end kernels
               istat = dmm(a1g, ajr_tmp, sigx_tmp, m=ngc, n=ngc, k=nr(ibas), opA=m_op_T)


### PR DESCRIPTION
Refactored Fortran array constructors into explicit do loops to prevent CUDA errors in certain OpenACC cases